### PR TITLE
Fixed creating objects when GenericRelation is set on model

### DIFF
--- a/autofixture/base.py
+++ b/autofixture/base.py
@@ -376,7 +376,7 @@ class AutoFixtureBase(object):
             else:
                 auto_created_through_model = True
         else:
-            auto_created_through_model = through._meta.auto_created
+            auto_created_through_model = through._meta.auto_created if through else False
 
         if auto_created_through_model:
             return self.process_field(instance, field)


### PR DESCRIPTION
When model has GenericRelation set then when trying to generate object field.rel.through in process_m2m method is None and it raises exception. This is fix for such situation.
