### PR TITLE
added FirstName and LastName generators

### DIFF
--- a/autofixture/generators.py
+++ b/autofixture/generators.py
@@ -304,6 +304,45 @@ class DecimalGenerator(Generator):
         return value
 
 
+class FirstNameGenerator(generators.Generator):
+	""" Generates a first name, either male or female """
+
+	def __init__(self, gender=None):
+		self.gender = gender
+		self.male = ['Abraham', 'Adam', 'Anthony', 'Brian', 'Bill', 'Ben', 'Calvin', 'David', 'Daniel',
+					 'George', 'Henry', 'Isaac', 'Ian', 'Jonathan', 'Jeremy', 'Jacob', 'John', 'Jerry',
+					 'Joseph', 'James', 'Larry', 'Michael', 'Mark', 'Paul', 'Peter', 'Phillip', 'Stephen', 
+					 'Tony', 'Titus', 'Trevor', 'Timothy', 'Victor', 'Vincent', 'Winston', 'Walt']
+		self.female = ['Abbie', 'Anna', 'Alice', 'Beth', 'Carrie', 'Christina' 'Danielle', 'Emma', 
+					   'Emily', 'Esther', 'Felicia', 'Grace', 'Gloria', 'Helen', 'Irene', 'Joanne', 
+					   'Joyce', 'Jessica', 'Kathy', 'Katie', 'Kelly', 'Linda', 'Lydia', 'Mandy', 'Mary', 
+					   'Olivia', 'Priscilla', 'Rebecca', 'Rachel', 'Susan', 'Sarah', 'Stacey', 'Vivian']
+		self.all = self.male + self.female
+
+	def generate(self):
+		if self.gender == 'M' or self.gender == 'Male':
+			return random.choice(self.male)
+		elif self.gender == 'F' or self.gender == 'Female':
+			return random.choice(self.female)
+		else:
+			return random.choice(self.all)
+
+
+class LastNameGenerator(generators.Generator):
+	""" Generates a last name """
+	
+	def __init__(self):
+		self.surname = ['Smith', 'Walker', 'Conroy', 'Stevens', 'Jones', 'Armstrong', 'Johnson',
+						'White', 'Stone', 'Strong', 'Olson', 'Lee', 'Forrest', 'Baker', 'Portman',
+						'Davis', 'Clark', 'Brown', 'Roberts', 'Ellis', 'Jackson', 'Marshall',
+						'Wang', 'Chen', 'Chou', 'Tang', 'Huang', 'Liu', 'Shih', 'Su', 'Song', 'Yang',
+						'Chan', 'Tsai', 'Wong', 'Hsu', 'Cheng', 'Chang', 'Wu', 'Lin', 'Yu', 'Yao', 
+						'Kang', 'Park', 'Kim', 'Choi', 'Ahn', 'Mujuni']
+
+	def generate(self):
+		return random.choice(self.surname)
+
+
 class EmailGenerator(StringGenerator):
     chars = string.ascii_lowercase
 


### PR DESCRIPTION
Added two more generators, which can generate first names (male or female) and last names. I manually created lists of common (American) first names and last names are American, Chinese, and Korean. 

`python setup.py test` passed without incident
