### PR TITLE
Update autofixtures.py to use timezone.now() like the DateTimeGenerator ...

### DIFF
--- a/autofixture/autofixtures.py
+++ b/autofixture/autofixtures.py
@@ -56,9 +56,6 @@ class UserFixture(AutoFixture):
         if self.username:
             self.field_values['username'] = generators.StaticGenerator(
                 self.username)
-        if self.password:
-            self.field_values['password'] = generators.StaticGenerator(
-                self.password)
 
     def unique_email(self, model, instance):
         if User.objects.filter(email=instance.email):


### PR DESCRIPTION
...class

avoid TypeError: can't compare offset-naive and offset-aware datetimes
