### PR TITLE
Fixes bug which causes exception when processed model contains GenericRelation field.

### DIFF
--- a/autofixture/base.py
+++ b/autofixture/base.py
@@ -2,6 +2,7 @@
 from django.db import models
 from django.db.models import fields
 from django.db.models.fields import related
+from django.contrib.contenttypes.generic import GenericRelation
 from django.utils.datastructures import SortedDict
 from django.utils.six import with_metaclass
 import autofixture
@@ -467,7 +468,12 @@ class AutoFixtureBase(object):
             ))
         if commit:
             instance.save()
-            for field in instance._meta.many_to_many:
+
+            #to handle particular case of GenericRelation
+            #in Django pre 1.6 it appears in .many_to_many
+            many_to_many = [f for f in instance._meta.many_to_many
+                            if not isinstance(f, GenericRelation)]
+            for field in many_to_many:
                 self.process_m2m(instance, field)
         signals.instance_created.send(
             sender=self,

--- a/autofixture_tests/models.py
+++ b/autofixture_tests/models.py
@@ -2,7 +2,8 @@
 import os
 from datetime import datetime
 from django.db import models
-
+from django.contrib.contenttypes.models import ContentType
+from django.contrib.contenttypes import generic
 
 filepath = os.path.dirname(os.path.abspath(__file__))
 
@@ -128,3 +129,11 @@ class ThroughModel(models.Model):
 class M2MModelThrough(models.Model):
     m2m = models.ManyToManyField(SimpleModel, related_name='m2mthrough_rel1',
         through=ThroughModel)
+
+class GFKModel(models.Model):
+    content_type = models.ForeignKey(ContentType)
+    object_id = models.PositiveIntegerField()
+    content_object = generic.GenericForeignKey('content_type', 'object_id')
+
+class GRModel(models.Model):
+    gr = generic.GenericRelation('GFKModel')


### PR DESCRIPTION
This is about the same issue as described in #4 and in #20.
`GenericRelation` appears in `instance._meta.many_to_many` whereas it is actually represents a one-to-many relationship. `GenericRelation` always have `.rel.through` equal `None` and it causes `AttributeError: 'NoneType' object has no attribute '_meta'` in `autofixture.base.AutoFixtureBase#process_m2m`.
PR contains test and fix.
