### PR TITLE
Support OneToOneField relationships

### DIFF
--- a/autofixture/base.py
+++ b/autofixture/base.py
@@ -231,6 +231,17 @@ class AutoFixtureBase(object):
         '''
         self.constraints.append(constraint)
 
+    def is_inheritance_parent(self, field):
+        '''
+        Checks if the field is the automatically created OneToOneField used by
+        django mulit-table inheritance
+        '''
+        return (
+            isinstance(field, related.OneToOneField) and
+            field.primary_key and
+            issubclass(field.model, field.rel.to)
+        )
+
     def get_generator(self, field):
         '''
         Return a value generator based on the field instance that is passed to
@@ -240,7 +251,7 @@ class AutoFixtureBase(object):
         '''
         if isinstance(field, fields.AutoField):
             return None
-        if isinstance(field, related.OneToOneField) and field.primary_key:
+        if self.is_inheritance_parent(field):
             return None
         if (
             field.default is not fields.NOT_PROVIDED and

--- a/autofixture/constraints.py
+++ b/autofixture/constraints.py
@@ -1,4 +1,5 @@
 # -*- coding: utf-8 -*-
+from django.db.models.fields import related
 
 
 class InvalidConstraint(Exception):
@@ -7,10 +8,22 @@ class InvalidConstraint(Exception):
         super(InvalidConstraint, self).__init__(*args, **kwargs)
 
 
+def _is_unique_field(field):
+    if not field.unique:
+        return False
+    if field.primary_key:
+        # Primary key fields should not generally be checked for unique constraints, except when the
+        # primary key is a OneToOne mapping to an external table not via table inheritance, in which
+        # case we don't want to create new objects which will overwrite existing objects.
+        return isinstance(field, related.OneToOneField) and not issubclass(field.model, field.rel.to)
+    else:
+        return True
+
+
 def unique_constraint(model, instance):
     error_fields = []
     for field in instance._meta.fields:
-        if field.unique and not field.primary_key:
+        if _is_unique_field(field):
             check = {field.name: getattr(instance, field.name)}
             unique = not bool(model._default_manager.filter(**check))
             if not unique:

--- a/autofixture_tests/models.py
+++ b/autofixture_tests/models.py
@@ -100,6 +100,10 @@ class O2OModel(models.Model):
     o2o = models.OneToOneField(SimpleModel)
 
 
+class O2OPrimaryKeyModel(models.Model):
+    o2o = models.OneToOneField(SimpleModel, primary_key=True)
+
+
 class InheritModel(SimpleModel):
     extrafloatfield = models.FloatField()
 

--- a/autofixture_tests/tests/test_base.py
+++ b/autofixture_tests/tests/test_base.py
@@ -11,7 +11,7 @@ from ..models import y2k
 from ..models import (
     SimpleModel, OtherSimpleModel, DeepLinkModel1, DeepLinkModel2,
     NullableFKModel, BasicModel, UniqueTestModel, UniqueTogetherTestModel,
-    RelatedModel, O2OModel, InheritModel, InheritUniqueTogetherModel,
+    RelatedModel, O2OModel, O2OPrimaryKeyModel, InheritModel, InheritUniqueTogetherModel,
     M2MModel, ThroughModel, M2MModelThrough, SelfReferencingModel,
     SelfReferencingModelNoNull, GFKModel, GRModel)
 
@@ -185,6 +185,26 @@ class TestRelations(TestCase):
     def test_generate_fk_for_o2o(self):
         # OneToOneField is the same as a ForeignKey with unique=True
         filler = AutoFixture(O2OModel, generate_fk=True)
+
+        all_o2o = set()
+        for obj in filler.create(10):
+            all_o2o.add(obj.o2o)
+
+        self.assertEqual(set(SimpleModel.objects.all()), all_o2o)
+
+    def test_follow_fk_for_o2o_primary_key(self):
+        # OneToOneField on primary key should follow if it is not table inheritance
+        filler = AutoFixture(O2OPrimaryKeyModel, follow_fk=True)
+
+        simple = SimpleModel.objects.create()
+        obj = filler.create()[0]
+        self.assertEqual(obj.o2o, simple)
+
+        self.assertRaises(CreateInstanceError, filler.create)
+
+    def test_generate_fk_for_o2o_primary_key(self):
+        # OneToOneField on primary key should follow if it is not table inheritance
+        filler = AutoFixture(O2OPrimaryKeyModel, generate_fk=True)
 
         all_o2o = set()
         for obj in filler.create(10):


### PR DESCRIPTION
Previously they were always assumed to be used in multi-table inheritance so
values would never be generated