### PR TITLE
Add support to model with strings in max_lenght

### DIFF
--- a/autofixture/generators.py
+++ b/autofixture/generators.py
@@ -158,7 +158,7 @@ class LoremGenerator(Generator):
                 paras = ['<p>%s</p>' % p for p in paras]
             lorem = u'\n\n'.join(paras)
         if self.max_length:
-            length = random.randint(round(self.max_length / 10),
+            length = random.randint(round(int(self.max_length) / 10),
                                     self.max_length)
             lorem = lorem[:max(1, length)]
         return lorem.strip()


### PR DESCRIPTION
Django code:

```
  title = models.CharField(max_length=250)
```

and 

```
  title = models.CharField(max_length="250")
```

are equal, but one of them make django-autofixture fail. This fix that.
