### PR TITLE
Fix unicode error when printing

### DIFF
--- a/autofixture/management/commands/loadtestdata.py
+++ b/autofixture/management/commands/loadtestdata.py
@@ -93,7 +93,7 @@ class Command(BaseCommand):
     def print_instance(self, sender, model, instance, **kwargs):
         if self.verbosity < 1:
             return
-        print('{0}(pk={1}): {2}'.format(
+        print(u'{0}(pk={1}): {2}'.format(
             '.'.join((
                 model._meta.app_label,
                 model._meta.object_name)),


### PR DESCRIPTION
Fixes unicode error related to printing output of model instance. Came across this when autogenerated model instance had unicode chars in name comming from FK model repr.

"""
autofixture/management/commands/loadtestdata.py", line 101, in print_instance
self.format_output(instance),
UnicodeEncodeError: 'ascii' codec can't encode character
"""

One letter fix, lucky us we don't charge by KLOC.