### PR TITLE
Replace count 0 exists

### DIFF
--- a/autofixture/constraints.py
+++ b/autofixture/constraints.py
@@ -26,8 +26,7 @@ def unique_constraint(model, instance):
         if _is_unique_field(field):
             check = {field.name: getattr(instance, field.name)}
 
-            unique = model._default_manager.filter(**check).count() == 0
-            if not unique:
+            if model._default_manager.filter(**check).exists():
                 error_fields.append(field)
     if error_fields:
         raise InvalidConstraint(error_fields)
@@ -44,8 +43,8 @@ def unique_together_constraint(model, instance):
                 check[field_name] = getattr(instance, field_name)
         if all(e is None for e in check.values()):
             continue
-        unique = model._default_manager.filter(**check).count() == 0
-        if not unique:
+
+        if model._default_manager.filter(**check).exists():
             error_fields.extend(
                 [instance._meta.get_field_by_name(field_name)[0]
                     for field_name in unique_fields])

--- a/autofixture/management/commands/loadtestdata.py
+++ b/autofixture/management/commands/loadtestdata.py
@@ -112,7 +112,7 @@ class Command(BaseCommand):
                         self.format_output(obj)))
         for field in instance._meta.many_to_many:
             qs = getattr(instance, field.name).all()
-            if qs.count():
+            if qs.exists():
                 print('|   {0} (count={1}):'.format(
                     field.name,
                     qs.count()))


### PR DESCRIPTION
Hello, in order to optimize the performances of the generation of data, I replaced count() == 0 with exists() because the query generated is lighter. Instead of having a count(*) on the objects you juste have a 

```SELECT (1) AS "a" FROM "my_table" WHERE (.....) LIMIT 1```