### PR TITLE
Handle None value in unique constraint check

### DIFF
--- a/autofixture/constraints.py
+++ b/autofixture/constraints.py
@@ -24,7 +24,13 @@ def unique_constraint(model, instance):
     error_fields = []
     for field in instance._meta.fields:
         if _is_unique_field(field):
-            check = {field.name: getattr(instance, field.name)}
+            value = getattr(instance, field.name)
+
+            # If the value is none and the field allows nulls, skip it
+            if value is None and field.null:
+                continue
+
+            check = {field.name: value}
 
             if model._default_manager.filter(**check).exists():
                 error_fields.append(field)

--- a/autofixture_tests/tests/test_base.py
+++ b/autofixture_tests/tests/test_base.py
@@ -348,8 +348,9 @@ class TestUniqueConstraints(FileSystemCleanupTestCase):
         )
         self.assertIn(constraints.unique_constraint, fixture.constraints)
         fixture.create_one()
-        with self.assertRaises(CreateInstanceError):
-            fixture.create_one()
+        # Creating another entry with a null value should not raise an
+        # exception as a unique column can contain multiple null values
+        fixture.create_one()
 
     def test_unique_together_constraint_nulls(self):
         fixture = AutoFixture(


### PR DESCRIPTION
According to the SQL standard, a NULL value does not count towards uniqueness in a column defined as UNIQUE. When checking constraints, ignore fields that allow NULL when the value is None.