### PR TITLE
Use inspect.signature if available

### DIFF
--- a/autofixture/__init__.py
+++ b/autofixture/__init__.py
@@ -1,9 +1,9 @@
 # -*- coding: utf-8 -*-
-import inspect
 import sys
 import warnings
 from autofixture.base import AutoFixture
 from autofixture.constraints import InvalidConstraint
+from autofixture.compat import getargnames
 
 
 if sys.version_info[0] < 3:
@@ -126,7 +126,7 @@ def create(model, count, *args, **kwargs):
         autofixture_class = AutoFixture
     # Get keyword arguments that the create_one method accepts and pass them
     # into create_one instead of AutoFixture.__init__
-    argnames = set(inspect.getargspec(autofixture_class.create_one).args)
+    argnames = set(getargnames(autofixture_class.create_one))
     argnames -= set(['self'])
     create_kwargs = {}
     for argname in argnames:

--- a/autofixture/base.py
+++ b/autofixture/base.py
@@ -1,5 +1,4 @@
 # -*- coding: utf-8 -*-
-import inspect
 import warnings
 from django.db.models import fields, ImageField
 from django.db.models.fields import related
@@ -8,8 +7,13 @@ from django.utils.six import with_metaclass
 import autofixture
 from autofixture import constraints, generators, signals
 from autofixture.values import Values
-
-from .compat import OrderedDict, get_GenericRelation, get_remote_field, get_remote_field_to
+from autofixture.compat import (
+    OrderedDict,
+    get_GenericRelation,
+    get_remote_field,
+    get_remote_field_to,
+    getargnames,
+)
 
 
 class CreateInstanceError(Exception):
@@ -527,7 +531,7 @@ class AutoFixtureBase(object):
             committed=commit)
 
         post_process_kwargs = {}
-        if 'commit' in inspect.getargspec(self.post_process_instance).args:
+        if 'commit' in getargnames(self.post_process_instance):
             post_process_kwargs['commit'] = commit
         else:
             warnings.warn(

--- a/autofixture/compat.py
+++ b/autofixture/compat.py
@@ -63,3 +63,16 @@ def get_remote_field_to(field):
         return field.rel.to
     else:
         return field.remote_field.model
+
+
+try:
+    # added in Python 3.0
+    from inspect import signature
+    def getargnames(callable):
+        return list(signature(callable).parameters.keys())
+
+except ImportError:
+    # loud DeprecationWarnings in 3.5
+    from inspect import getargspec
+    def getargnames(callable):
+        return getargspec(callable).args


### PR DESCRIPTION
Loud deprecation warnings seem to have been turned on in Python 3.5 leading to annoyingness. I added a little shim function to get the argument names, either from `inspect.getargspec` or `inspect.signature`, as available.

https://docs.python.org/3/library/inspect.html#inspect.getargspec