### PR TITLE
Explicitly close files to avoid ResourceWarnings

### DIFF
--- a/autofixture/__init__.py
+++ b/autofixture/__init__.py
@@ -201,9 +201,12 @@ def autodiscover():
         # but doesn't actually try to import the module. So skip this app if
         # its autofixtures.py doesn't exist
         try:
-            imp.find_module('autofixtures', app_path)
+            file, _, _ = imp.find_module('autofixtures', app_path)
         except ImportError:
             continue
+        else:
+            if file:
+                file.close()
 
         # Step 3: import the app's autofixtures file. If this has errors we want them
         # to bubble up.
@@ -215,9 +218,12 @@ def autodiscover():
 
     for app, app_path in app_paths.items():
         try:
-            imp.find_module('tests', app_path)
+            file, _, _ = imp.find_module('tests', app_path)
         except ImportError:
             continue
+        else:
+            if file:
+                file.close()
 
         try:
             importlib.import_module("%s.tests" % app)

--- a/autofixture_tests/tests/test_generator.py
+++ b/autofixture_tests/tests/test_generator.py
@@ -109,16 +109,18 @@ class ImageGeneratorTests(FileSystemCleanupTestCase):
         file_path = os.path.join(settings.MEDIA_ROOT, media_file)
         self.assertTrue(os.path.exists(file_path))
 
-        image = Image.open(file_path)
-        self.assertTrue(image.size in generators.ImageGenerator.default_sizes)
+        with open(file_path, 'rb') as f:
+            image = Image.open(f)
+            self.assertTrue(image.size in generators.ImageGenerator.default_sizes)
 
     def test_width_height(self):
         media_file = generators.ImageGenerator(125, 225).generate()
         file_path = os.path.join(settings.MEDIA_ROOT, media_file)
         self.assertTrue(os.path.exists(file_path))
 
-        image = Image.open(file_path)
-        self.assertTrue(image.size, (125, 225))
+        with open(file_path, 'rb') as f:
+            image = Image.open(f)
+            self.assertTrue(image.size, (125, 225))
 
     def test_filenames_dont_clash(self):
         media_file = generators.ImageGenerator(100, 100).generate()


### PR DESCRIPTION
Maybe a bit excessive, but it's easy enough to suppress scores of ResourceWarnings.

```
/Users/ntimkovich/Code/django-autofixture/autofixture/__init__.py:203: ResourceWarning: unclosed file <_io.TextIOWrapper name='/Users/ntimkovich/Code/django-autofixture/autofixture_tests/appconfig_test/autofixtures.py' mode='r' encoding='utf-8'>
  imp.find_module('autofixtures', app_path)

/Users/ntimkovich/Code/django-autofixture/autofixture/__init__.py:217: ResourceWarning: unclosed file <_io.TextIOWrapper name='/Users/ntimkovich/.pyenv/versions/djaf/lib/python3.5/site-packages/django/contrib/admin/tests.py' mode='r' encoding='utf-8'>
  imp.find_module('tests', app_path)
```
&times; a few hundred

:sparkles: Super clean! :sparkles: