### PR TITLE
Fix `process_field` so that it works for m2m fields in Django 2.0

### DIFF
--- a/autofixture/base.py
+++ b/autofixture/base.py
@@ -1,5 +1,6 @@
 # -*- coding: utf-8 -*-
 import warnings
+from django import VERSION
 from django.db.models import fields, ImageField
 from django.conf import settings
 from django.db.models.fields import related
@@ -403,11 +404,14 @@ class AutoFixtureBase(object):
         value = generator()
         return value
 
-    def process_field(self, instance, field):
+    def process_field(self, instance, field, is_m2m=False):
         value = self.get_value(field)
         if value is self.IGNORE_FIELD:
             return
-        setattr(instance, field.name, value)
+        if is_m2m and VERSION[0] >= 2:
+            getattr(instance, field.name).set(value)
+        else:
+            setattr(instance, field.name, value)
 
     def process_m2m(self, instance, field):
         # check django's version number to determine how intermediary models
@@ -417,7 +421,7 @@ class AutoFixtureBase(object):
         auto_created_through_model = through._meta.auto_created
 
         if auto_created_through_model:
-            return self.process_field(instance, field)
+            return self.process_field(instance, field, is_m2m=True)
         # if m2m relation has intermediary model:
         #   * only generate relation if 'generate_m2m' is given
         #   * first generate intermediary model and assign a newly created


### PR DESCRIPTION
Support for direct assignment in manytomany fields was removed in Django 2.0 (see: https://docs.djangoproject.com/en/2.0/releases/2.0/#features-removed-in-2-0).

This commit adds an extra param to `process_field` to indicate that the field being processed is a m2m and assignment should be handled through `.set` instead.