### PR TITLE
use non-vendor six lib

### DIFF
--- a/autofixture/base.py
+++ b/autofixture/base.py
@@ -3,7 +3,7 @@ import warnings
 from django.db.models import fields, ImageField
 from django.conf import settings
 from django.db.models.fields import related
-from django.utils.six import with_metaclass
+from six import with_metaclass
 
 import autofixture
 from autofixture import constraints, generators, signals

--- a/autofixture/values.py
+++ b/autofixture/values.py
@@ -1,4 +1,4 @@
-from django.utils.six import with_metaclass
+from six import with_metaclass
 
 
 class ValuesMetaclass(type):

--- a/setup.py
+++ b/setup.py
@@ -48,6 +48,7 @@ setup(
     description = 'Provides tools to auto generate test data.',
     long_description = long_description,
     author = UltraMagicString('Gregor Müllegger'),
+    install_requires=["six"],
     author_email = 'gregor@muellegger.de',
     classifiers = [
         'Development Status :: 4 - Beta',


### PR DESCRIPTION
Django removed the vendor provided `six` library. 

https://docs.djangoproject.com/en/3.1/releases/3.0/#removed-private-python-2-compatibility-apis

added it as a dependency so `autofixture` will continue to work.  fixes #112 